### PR TITLE
fix: detect macOS /dev/cu.* devices in port selection

### DIFF
--- a/lua/Arduino-Nvim/init.lua
+++ b/lua/Arduino-Nvim/init.lua
@@ -411,7 +411,7 @@ function M.select_port_gui()
 	-- Extract port names from the arduino-cli output
 	local ports = {}
 	for line in result:gmatch("[^\r\n]+") do
-		if line:match("^/dev/tty") or line:match("^COM") then -- Matches Linux/macOS and Windows COM port formats
+		if line:match("^/dev/tty") or line:match("^/dev/cu") or line:match("^COM") then -- Matches Linux/macOS and Windows COM port formats
 			table.insert(ports, line:match("^(%S+)")) -- Capture the port name only
 		end
 	end


### PR DESCRIPTION
On macOS, arduino-cli board list outputs /dev/cu.* devices (call-up devices) instead of /dev/tty.* devices. This fix adds support for /dev/cu.* pattern matching so the port selection GUI properly detects connected Arduino/ESP8266 boards on macOS.

Fixes port detection issue where ESP8266 devices connected via USB serial adapters (e.g., /dev/cu.usbserial-120) were not being recognized.