### PR TITLE
feat: add support for compile options

### DIFF
--- a/lua/Arduino-Nvim/board_config.lua
+++ b/lua/Arduino-Nvim/board_config.lua
@@ -60,6 +60,7 @@ function M.load_or_create_config()
           _ArduinoConfigValues.board = settings.board or _ArduinoConfigValues.board
           _ArduinoConfigValues.port = settings.port or _ArduinoConfigValues.port
           _ArduinoConfigValues.baudrate = settings.baudrate or _ArduinoConfigValues.baudrate
+          _ArduinoConfigValues.compile_options = settings.compile_options or _ArduinoConfigValues.compile_options
 				vim.notify(
           "Config loaded from file: " .. _ArduinoConfigValues.config_file,
           vim.log.levels.INFO)

--- a/lua/Arduino-Nvim/commands.lua
+++ b/lua/Arduino-Nvim/commands.lua
@@ -143,8 +143,18 @@ function M.compile(callback)
 	-- Command to compile in the current directory
   local cmd = "arduino-cli compile --fqbn " 
     .. _ArduinoConfigValues.board 
-    .. " " 
-    .. vim.fn.shellescape(vim.fn.expand("%:p:h"))
+
+  -- Check for compile options available for arduino-cli compile
+  if next(_ArduinoConfigValues.compile_options) ~= nil then
+    if _ArduinoConfigValues.compile_options.build_property ~= "" then
+      cmd = cmd .. " --build-property " .. _ArduinoConfigValues.compile_options.build_property
+    end
+  end
+
+  -- Add current folder at the end
+    cmd = cmd 
+      .. " " 
+      .. vim.fn.shellescape(vim.fn.expand("%:p:h"))
 
 	-- Run the command asynchronously
 	vim.fn.jobstart(cmd, {

--- a/lua/Arduino-Nvim/init.lua
+++ b/lua/Arduino-Nvim/init.lua
@@ -10,6 +10,7 @@ _ArduinoConfigValues = {
   use_default_keymaps = true,
   use_default_commands = true,
   keymaps = {},
+  compile_options = {},
 }
 
 local function set_default_commands(commands, b_config, picker)


### PR DESCRIPTION
Hey, I hope you are doing ok. Thanks for adding my last PR to the repo :D 

I have this tiny PR just to add a minimum support for compile options that can be defined in the `.arduino_config.lua`. Right now it only supports `--build-property` option since that's what I need right now, but I (or any one else) can extend this config to handle all the options for compile, I just want to add a small feat this time.

Maybe future improvements for this feature could be:
- Hot reload when `.arduino_config.lua` is updated
- Support for `arduino-cli upload` options

Let me know if you have any questions/suggestions/changes for this PR.